### PR TITLE
fix(instance_type):主动刷新缓存

### DIFF
--- a/cmd/api/handler/instance.go
+++ b/cmd/api/handler/instance.go
@@ -212,7 +212,7 @@ func ListInstanceType(ctx *gin.Context) {
 		return
 	}
 	logs.Logger.Infof("provider:[%s] regionId:[%s] zoneId:[%s]", provider, regionId, zoneId)
-	zones, err := service.ListInstanceType(service.ListInstanceTypeRequest{
+	zones, err := service.ListInstanceType(ctx, service.ListInstanceTypeRequest{
 		Provider: provider,
 		RegionId: regionId,
 		ZoneId:   zoneId,

--- a/cmd/api/handler/network.go
+++ b/cmd/api/handler/network.go
@@ -218,7 +218,7 @@ func CreateSecurityGroupWithRules(ctx *gin.Context) {
 		response.MkResponse(ctx, http.StatusBadRequest, err.Error(), nil)
 		return
 	}
-	if len(req.Rules) == 0 {
+	if len(req.Rules) == 0 || req.Rules[0].Protocol == "" {
 		response.MkResponse(ctx, http.StatusOK, response.Success, groupId)
 		return
 	}

--- a/internal/service/instance.go
+++ b/internal/service/instance.go
@@ -273,7 +273,10 @@ type InstanceTypeByZone struct {
 	Memory             int    `json:"memory"`
 }
 
-func ListInstanceType(req ListInstanceTypeRequest) (ListInstanceTypeResponse, error) {
+func ListInstanceType(ctx context.Context, req ListInstanceTypeRequest) (ListInstanceTypeResponse, error) {
+	if len(zoneInsTypeCache) == 0 {
+		RefreshCache(ctx)
+	}
 	zoneMap, ok := zoneInsTypeCache[req.Provider]
 	if !ok {
 		return ListInstanceTypeResponse{}, nil

--- a/internal/service/network.go
+++ b/internal/service/network.go
@@ -152,6 +152,7 @@ func refreshAccount(t *SimpleTask) error {
 	updateOrCreateSwitch(ctx, vpcs, t)
 	groups := updateOrCreateSecurityGroups(ctx, vpcs, t)
 	updateOrCreateSecurityGroupRules(ctx, groups, t)
+	RefreshCache(ctx)
 	return nil
 }
 
@@ -204,7 +205,7 @@ func updateOrCreateSwitch(ctx context.Context, vpcs []cloud.VPC, t *SimpleTask) 
 
 func updateOrCreateSecurityGroups(ctx context.Context, vpcs []cloud.VPC, t *SimpleTask) []cloud.SecurityGroup {
 	groups := make([]cloud.SecurityGroup, 0, 64)
-	groupReq := cloud.GetSecurityGroupRequest{}
+	groupReq := cloud.DescribeSecurityGroupsRequest{}
 	for _, vpc := range vpcs {
 		groupReq.VpcId = vpc.VpcId
 		groupReq.RegionId = vpc.RegionId
@@ -213,7 +214,7 @@ func updateOrCreateSecurityGroups(ctx context.Context, vpcs []cloud.VPC, t *Simp
 			logs.Logger.Errorf("getProvider failed.err: %s", err.Error())
 			continue
 		}
-		groupRes, err := provider.GetSecurityGroup(groupReq)
+		groupRes, err := provider.DescribeSecurityGroups(groupReq)
 		if err != nil {
 			continue
 		}

--- a/pkg/cloud/aliyun/aliyun.go
+++ b/pkg/cloud/aliyun/aliyun.go
@@ -471,7 +471,7 @@ func (p Aliyun) AddEgressSecurityGroupRule(req cloud.AddSecurityGroupRuleRequest
 	return nil
 }
 
-func (p *Aliyun) GetSecurityGroup(req cloud.GetSecurityGroupRequest) (cloud.GetSecurityGroupResponse, error) {
+func (p *Aliyun) DescribeSecurityGroups(req cloud.DescribeSecurityGroupsRequest) (cloud.DescribeSecurityGroupsResponse, error) {
 	var page int32 = 1
 	groups := make([]cloud.SecurityGroup, 0, 128)
 
@@ -485,7 +485,7 @@ func (p *Aliyun) GetSecurityGroup(req cloud.GetSecurityGroupRequest) (cloud.GetS
 		response, err := p.ecsClient.DescribeSecurityGroups(request)
 		if err != nil {
 			logs.Logger.Errorf("GetSecurityGroup Aliyun failed.err: [%v], req[%v]", err, req)
-			return cloud.GetSecurityGroupResponse{}, err
+			return cloud.DescribeSecurityGroupsResponse{}, err
 		}
 		if response != nil && response.Body != nil && response.Body.SecurityGroups != nil {
 			for _, group := range response.Body.SecurityGroups.SecurityGroup {
@@ -508,7 +508,7 @@ func (p *Aliyun) GetSecurityGroup(req cloud.GetSecurityGroupRequest) (cloud.GetS
 			logs.Logger.Errorf("GetSecurityGroup failed,error: %v pageNumber:%d pageSize:%d vpcId:%s", err, page, 50, req.VpcId)
 		}
 	}
-	return cloud.GetSecurityGroupResponse{Groups: groups}, nil
+	return cloud.DescribeSecurityGroupsResponse{Groups: groups}, nil
 }
 
 func (p *Aliyun) GetRegions() (cloud.GetRegionsResponse, error) {

--- a/pkg/cloud/model.go
+++ b/pkg/cloud/model.go
@@ -127,12 +127,12 @@ type AddSecurityGroupRuleRequest struct {
 	PrefixListId    string
 }
 
-type GetSecurityGroupRequest struct {
+type DescribeSecurityGroupsRequest struct {
 	VpcId    string
 	RegionId string
 }
 
-type GetSecurityGroupResponse struct {
+type DescribeSecurityGroupsResponse struct {
 	Groups []SecurityGroup
 }
 

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -30,7 +30,7 @@ type Provider interface {
 	CreateSecurityGroup(req CreateSecurityGroupRequest) (CreateSecurityGroupResponse, error)
 	AddIngressSecurityGroupRule(req AddSecurityGroupRuleRequest) error
 	AddEgressSecurityGroupRule(req AddSecurityGroupRuleRequest) error
-	GetSecurityGroup(req GetSecurityGroupRequest) (GetSecurityGroupResponse, error)
+	DescribeSecurityGroups(req DescribeSecurityGroupsRequest) (DescribeSecurityGroupsResponse, error)
 	GetRegions() (GetRegionsResponse, error)
 	GetZones(req GetZonesRequest) (GetZonesResponse, error)
 	DescribeAvailableResource(req DescribeAvailableResourceRequest) (DescribeAvailableResourceResponse, error)


### PR DESCRIPTION
修复了如下两个问题:
1. 初次添加云厂商账号后不会刷新机型的 bug
> 修复方式: 在添加云厂商账号后不止同步账号资源, 同时检查机型对应的本地缓存, 无则主动刷新
2. 创建安全组的时候, 不添加规则会在后端日志报错, 同时返回成功给前端
> 修复方式: 在判断前端安全组规则的protocol 为空时, 直接跳过添加安全组规则的逻辑